### PR TITLE
♻ Format datetime

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod api;
 mod client;
 mod video;
 
+use chrono::Local;
 use std::env::args;
 use std::error::Error;
 
@@ -25,7 +26,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         response_to_videos(response).expect("Failed to determine videos from the response.");
 
     for video in videos {
-        println!("{}: {} ({})", video.id, video.title, video.scheduled_at);
+        println!(
+            "{}: {} ({})",
+            video.id,
+            video.title,
+            video.scheduled_at.with_timezone(&Local)
+        );
     }
 
     Ok(())

--- a/src/video.rs
+++ b/src/video.rs
@@ -1,7 +1,9 @@
+use chrono::{DateTime, Utc, TimeZone};
+
 pub struct Video {
     pub id: String,
     pub title: String,
-    pub scheduled_at: u64,
+    pub scheduled_at: DateTime<Utc>,
 }
 
 impl Video {
@@ -9,7 +11,7 @@ impl Video {
         Self {
             id: String::from(id),
             title: String::from(title),
-            scheduled_at,
+            scheduled_at: Utc.timestamp(scheduled_at as i64, 0),
         }
     }
 }


### PR DESCRIPTION
**Before**
```
❯ cargo run UCuvk5PilcvDECU7dDZhQiEw
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `target\debug\schetube.exe UCuvk5PilcvDECU7dDZhQiEw`
17sSLuAhLEA: 【マリオカート8DX】ポンも即終了も卒業したの【#フルトイ/白雪 巴/にじさんじ】 (1608296400)
```

**After**
```
❯ cargo run UCuvk5PilcvDECU7dDZhQiEw
   Compiling schetube v0.1.0 (C:\Users\Siketyan\Projects\Siketyan\schetube)
    Finished dev [unoptimized + debuginfo] target(s) in 5.04s
     Running `target\debug\schetube.exe UCuvk5PilcvDECU7dDZhQiEw`
17sSLuAhLEA: 【マリオカート8DX】ポンも即終了も卒業したの【#フルトイ/白雪 巴/にじさんじ】 (2020-12-18 22:00:00 +09:00)
```
